### PR TITLE
chore(pom): improve POM files

### DIFF
--- a/.run/clean_install.run.xml
+++ b/.run/clean_install.run.xml
@@ -20,18 +20,24 @@
       </option>
       <option name="myRunnerParameters">
         <MavenRunnerParameters>
+          <option name="cmdOptions" />
           <option name="profiles">
             <set />
           </option>
           <option name="goals">
             <list>
+              <option value="-U" />
               <option value="clean" />
               <option value="install" />
             </list>
           </option>
+          <option name="multimoduleDir" />
           <option name="pomFileName" />
           <option name="profilesMap">
             <map />
+          </option>
+          <option name="projectsCmdOptionValues">
+            <list />
           </option>
           <option name="resolveToWorkspace" value="false" />
           <option name="workingDirPath" value="$PROJECT_DIR$" />

--- a/domibusConnectorAPI/pom.xml
+++ b/domibusConnectorAPI/pom.xml
@@ -49,7 +49,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
-                <version>1.0.2</version>
                 <executions>
                     <execution>
                         <phase>pre-site</phase>
@@ -91,7 +90,6 @@
                             <goal>wsdl2java</goal>
                         </goals>
                         <configuration>
-                            <!--                            <sourceRoot>${basedir}/src/main/java</sourceRoot>-->
                             <encoding>UTF-8</encoding>
                             <wsdlOptions>
                                 <wsdlOption>

--- a/domibusConnectorAPIlib/pom.xml
+++ b/domibusConnectorAPIlib/pom.xml
@@ -11,22 +11,13 @@
     <name>${project.artifactId}</name>
     <description>Provides helper classes and methods which can be used in connector, connectorClient and connectorGatewayPlugin</description>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorAPI</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <!-- other dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
@@ -39,14 +30,26 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.junit.jupiter</groupId>-->
-        <!--            <artifactId>junit-jupiter-engine</artifactId>-->
-        <!--        </dependency>-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/domibusConnectorController/pom.xml
+++ b/domibusConnectorController/pom.xml
@@ -10,11 +10,33 @@
     <name>${project.artifactId}</name>
     <description>Does the business work with the messages: Generates the evidences, resolves and verifies the ASIC-S container, creates the TRUST-Tokens. It hands over the messages to the GWLink module for GW-Communication and to the BackendLinkModule for communication with the connectorClients. For this purpose it uses other modules like persistence, evidenceToolkit, securityToolkit,...</description>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorSecurityToolkit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorEvidencesToolkit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorPersistence</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.ecodex.utils</groupId>
+            <artifactId>spring-quartz-scheduled</artifactId>
+            <version>${eu.ecodex.utils.version}</version>
+        </dependency>
+        <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jta-atomikos</artifactId>
@@ -23,6 +45,43 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-artemis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- db dependencies -->
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.15.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- other dependencies -->
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-server</artifactId>
@@ -33,63 +92,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.activemq</groupId>-->
-        <!--            <artifactId>activemq-kahadb-store</artifactId>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorSecurityToolkit</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorEvidencesToolkit</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>domibusConnectorPersistence</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-quartz</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>eu.ecodex.utils</groupId>
-            <artifactId>spring-quartz-scheduled</artifactId>
-            <version>${eu.ecodex.utils.version}</version>
-        </dependency>
-        <!-- JMS -->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.activemq</groupId>-->
-        <!--            <artifactId>activemq-broker</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.activemq</groupId>-->
-        <!--            <artifactId>activemq-spring</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.springframework.boot</groupId>-->
-        <!--            <artifactId>spring-boot-autoconfigure</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>com.sun.xml.bind</groupId>-->
-        <!--            <artifactId>jaxb-impl</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>javax.xml.bind</groupId>-->
-        <!--            <artifactId>jaxb-api</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>com.sun.xml.bind</groupId>-->
-        <!--            <artifactId>jaxb-core</artifactId>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -115,18 +121,9 @@
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-el-api</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-jasper-el</artifactId>-->
-        <!--        </dependency>-->
         <!-- test dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -168,7 +165,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
@@ -200,41 +197,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <version>1.15.2</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
     <build>
-        <!-- activate resource filtering to provide the tests with correct properties for the environment
-            BUT only filter resources from specific folder to avoid malforming the other resources
+        <!--
+        activate resource filtering to provide the tests with correct properties for the environment
+        BUT only filter resources from specific folder to avoid malforming the other resources
         -->
         <testResources>
             <testResource>

--- a/domibusConnectorControllerAPI/pom.xml
+++ b/domibusConnectorControllerAPI/pom.xml
@@ -10,19 +10,13 @@
     <name>${project.artifactId}</name>
     <description>This module provides the internal connector interfaces for binding a GatewayLink-Module or a BackendLink module to the connectorModule</description>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorAPI</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
+        <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
@@ -40,9 +34,35 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+        </dependency>
+        <!-- other dependencies -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -57,22 +77,6 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-commons</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/domibusConnectorControllerLIB/pom.xml
+++ b/domibusConnectorControllerLIB/pom.xml
@@ -9,9 +9,15 @@
     <artifactId>domibusConnectorControllerLIB</artifactId>
     <description>Contains common code of all connector modules, like property configuration checkers, helper, ...</description>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorAPIlib</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -19,10 +25,10 @@
             <artifactId>spring-property-configuration-manager</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorAPIlib</artifactId>
-            <version>${project.version}</version>
+            <groupId>eu.ecodex.utils</groupId>
+            <artifactId>spring-property-configuration-manager-api</artifactId>
         </dependency>
+        <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
@@ -40,13 +46,14 @@
             <artifactId>spring-aspects</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.ecodex.utils</groupId>
-            <artifactId>spring-property-configuration-manager-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+        <!-- other dependencies -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -54,8 +61,8 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -66,18 +73,13 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-el-api</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-jasper-el</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorTestData</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -86,14 +88,6 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/domibusConnectorDistribution/pom.xml
+++ b/domibusConnectorDistribution/pom.xml
@@ -14,6 +14,7 @@
         <run.env>test</run.env>
     </properties>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorUI</artifactId>
@@ -40,7 +41,6 @@
         <dependency>
             <groupId>eu.domibus.connector.plugin</groupId>
             <artifactId>domibus-connector-plugin-distribution</artifactId>
-            <version>4.4.0</version>
             <type>zip</type>
         </dependency>
     </dependencies>
@@ -48,6 +48,7 @@
         <finalName>domibusConnector</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -66,6 +67,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>

--- a/domibusConnectorDocumentation/pom.xml
+++ b/domibusConnectorDocumentation/pom.xml
@@ -88,7 +88,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>copy-asciidoc-resources</id>
@@ -113,6 +112,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>

--- a/domibusConnectorDssToolkit/pom.xml
+++ b/domibusConnectorDssToolkit/pom.xml
@@ -8,10 +8,17 @@
     </parent>
     <artifactId>domibusConnectorDssToolkit</artifactId>
     <dependencies>
+        <!-- domibus modules and libs-->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerLIB</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>eu.ecodex.utils</groupId>
             <artifactId>spring-boot-property-converter</artifactId>
         </dependency>
+        <!-- dss dependencies -->
         <dependency>
             <groupId>eu.europa.ec.joinup.sd-dss</groupId>
             <artifactId>dss-document</artifactId>
@@ -25,10 +32,6 @@
                     <groupId>org.apache.santuario</groupId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.santuario</groupId>
-            <artifactId>xmlsec</artifactId>
         </dependency>
         <dependency>
             <groupId>eu.europa.ec.joinup.sd-dss</groupId>
@@ -54,10 +57,21 @@
             <groupId>eu.europa.ec.joinup.sd-dss</groupId>
             <artifactId>dss-pades</artifactId>
         </dependency>
+        <!-- other dependencies -->
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>domibusConnectorControllerLIB</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.apache.santuario</groupId>
+            <artifactId>xmlsec</artifactId>
+        </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/domibusConnectorEvidencesToolkit/pom.xml
+++ b/domibusConnectorEvidencesToolkit/pom.xml
@@ -8,12 +8,64 @@
     </parent>
     <artifactId>domibusConnectorEvidencesToolkit</artifactId>
     <name>${project.artifactId}</name>
-    <description>The evidence toolkit contains the evidence releated services. It is is responsibly for creating the evidences.</description>
+    <description>The evidence toolkit contains the evidence related services. It is responsibly for creating the evidences.</description>
     <dependencies>
+        <!-- domibus modules and libs-->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerLIB</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerAPI</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorDssToolkit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- other dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcmail-jdk15on</artifactId>
+        </dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -23,10 +75,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -41,67 +89,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerLIB</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-        </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.santurio</groupId>-->
-        <!--            <artifactId>xmlsec</artifactId>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-el-api</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-jasper-el</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerAPI</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>domibusConnectorDssToolkit</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/domibusConnectorLink/pom.xml
+++ b/domibusConnectorLink/pom.xml
@@ -8,6 +8,32 @@
     </parent>
     <artifactId>domibusConnectorLink</artifactId>
     <dependencies>
+        <!-- spring dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web-services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz</artifactId>
+        </dependency>
+        <!-- apache cxf dependencies -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-policy</artifactId>
@@ -31,43 +57,49 @@
             <artifactId>cxf-spring-boot-starter-jaxws</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxws</artifactId>
+        </dependency>
+        <!-- domibus modules and libs-->
+        <!-- moving spring-property-configuration-manager-api dependency, make the build fails  -->
+        <dependency>
+            <groupId>eu.ecodex.utils</groupId>
+            <artifactId>spring-property-configuration-manager-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerLIB</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorPersistence</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- other dependencies -->
+        <dependency>
+            <groupId>com.github.database-rider</groupId>
+            <artifactId>rider-spring</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web-services</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.jms</groupId>
             <artifactId>javax.jms-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <groupId>eu.domibus</groupId>
+            <artifactId>domibus-ws-stubs</artifactId>
+            <version>4.1.3</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jms</artifactId>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorPersistence</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.ecodex.utils</groupId>
-            <artifactId>spring-property-configuration-manager-api</artifactId>
-        </dependency>
-        <!-- Test dependencies -->
+        <!-- test dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
@@ -107,54 +139,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerLIB</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-frontend-jaxws</artifactId>
-        </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.junit.jupiter</groupId>-->
-        <!--            <artifactId>junit-jupiter-engine</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-        <dependency>
-            <groupId>eu.domibus</groupId>
-            <artifactId>domibus-ws-stubs</artifactId>
-            <version>4.1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorPersistence</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorTestData</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-quartz</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.database-rider</groupId>
-            <artifactId>rider-spring</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/domibusConnectorPersistence/pom.xml
+++ b/domibusConnectorPersistence/pom.xml
@@ -11,6 +11,22 @@
     <name>${project.artifactId}</name>
     <description>This module is responsibly for persisting the messages and message contents into a persistent storage (Database).</description>
     <dependencies>
+        <!-- domibus modules and libs-->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerLIB</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerAPI</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.ecodex.utils</groupId>
+            <artifactId>spring-boot-property-converter</artifactId>
+        </dependency>
+        <!-- spring framework -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -30,17 +46,38 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>
-        <!-- findbugs -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <!-- other dependencies -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
-        <!-- commons lang -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <!-- test -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <!-- test dependencies-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -57,10 +94,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>com.github.database-rider</groupId>-->
-        <!--            <artifactId>rider-junit5</artifactId>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
@@ -140,46 +173,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-crypto</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerAPI</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.ecodex.utils</groupId>
-            <artifactId>spring-boot-property-converter</artifactId>
-        </dependency>
-        <dependency>
             <groupId>eu.domibus.connector</groupId>
             <artifactId>domibusConnectorTestData</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerLIB</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -202,7 +199,7 @@
             <id>oracle</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </dependency>
             </dependencies>

--- a/domibusConnectorSecurityToolkit/pom.xml
+++ b/domibusConnectorSecurityToolkit/pom.xml
@@ -11,8 +11,9 @@
     <description>The securityToolkitModule resolves and creates the ASIC-S Container. Its a bridge betweent the
         connector and the securityLib</description>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerLIB</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -21,6 +22,34 @@
             <artifactId>domibusConnectorDssToolkit</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerAPI</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- dss dependencies -->
         <dependency>
             <groupId>eu.europa.ec.joinup.sd-dss</groupId>
             <artifactId>dss-utils-apache-commons</artifactId>
@@ -57,6 +86,15 @@
             <groupId>eu.europa.ec.joinup.sd-dss</groupId>
             <artifactId>dss-pades-pdfbox</artifactId>
         </dependency>
+        <!-- other dependencies -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>eu.ecodex.utils</groupId>
+            <artifactId>spring-boot-property-converter</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
@@ -69,6 +107,11 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <!-- tests dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
@@ -105,22 +148,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <scope>test</scope>
@@ -148,32 +175,8 @@
             <artifactId>liquibase-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-el-api</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.tomcat</groupId>-->
-        <!--            <artifactId>tomcat-jasper-el</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerAPI</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
@@ -186,7 +189,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorTestData</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -197,31 +200,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>eu.ecodex.utils</groupId>
-            <artifactId>spring-boot-property-converter</artifactId>
-        </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>com.sun.xml.bind</groupId>-->
-        <!--            <artifactId>jaxb-impl</artifactId>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
-        <!-- activate resource filtering to provide the tests with correct properties for the environment,
-               BUT only filter specific folder!!! so the other resources are not malformed during filtering!
+        <!--
+        activate resource filtering to provide the tests with correct properties for the environment,
+        BUT only filter specific folder!!! so the other resources are not malformed during filtering!
         -->
-        <!-- activate resource filtering to provide the tests with correct properties for the environment
-                    BUT only filter resources from specific folder to avoid malforming the other resources
-                -->
+        <!--
+        activate resource filtering to provide the tests with correct properties for the environment
+        BUT only filter resources from specific folder to avoid malforming the other resources
+        -->
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>
@@ -252,7 +244,6 @@
                                     <version>${eu.ecodex.utils.version}</version>
                                     <type>xml</type>
                                     <overWrite>true</overWrite>
-                                    <!--<outputAbsoluteArtifactFilename>target/test-classes/log4j2-test.xml</outputAbsoluteArtifactFilename>-->
                                     <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                                     <destFileName>log4j2-test.xml</destFileName>
                                 </artifactItem>

--- a/domibusConnectorStarter/pom.xml
+++ b/domibusConnectorStarter/pom.xml
@@ -13,19 +13,19 @@
         <java.version>1.8</java.version>
     </properties>
     <dependencies>
-        <!-- connector parts -->
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorAPI</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorController</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -36,18 +36,14 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorPersistence</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- additional spring parts -->
+        <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -66,10 +62,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+        <!-- other dependencies -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
         </dependency>
+        <!-- db dependencies -->
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
@@ -78,22 +80,18 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <!--            <scope>provided</scope>-->
         </dependency>
     </dependencies>
 </project>

--- a/domibusConnectorTestData/pom.xml
+++ b/domibusConnectorTestData/pom.xml
@@ -10,10 +10,45 @@
     <name>${project.artifactId}</name>
     <description>This module contains testData for Tests. To make the TestData reusable through the different modules of the project.</description>
     <dependencies>
+        <!-- domibus modules and libs-->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorControllerAPI</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorAPI</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorAPIlib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -21,10 +56,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -38,38 +69,11 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorControllerAPI</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorAPI</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorAPIlib</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>

--- a/domibusConnectorUI/pom.xml
+++ b/domibusConnectorUI/pom.xml
@@ -9,44 +9,41 @@
     <artifactId>domibusConnectorUI</artifactId>
     <packaging>jar</packaging>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorUILib</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorStarter</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j2</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorLink</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>domibusConnectorDocumentation</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>eu.ecodex.utils</groupId>
             <artifactId>spring-property-configuration-manager-vaadin-ui</artifactId>
         </dependency>
+        <!-- spring dependencies -->
         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-spring-boot-starter</artifactId>
-            <version>${vaadin.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-server</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.vaadin.klaudeta</groupId>
-            <artifactId>grid-pagination</artifactId>
-            <version>2.0.10</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>vaadin</artifactId>
-                    <groupId>com.vaadin</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+        <!-- db dependencies -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -71,7 +68,7 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
         </dependency>
-        <!-- will not build on external build server, because com.oracle:ojdbc7:12.1.0.1:jar 
+        <!-- will not build on external build server, because com.oracle:ojdbc7:12.1.0.1:jar
 			is not in public maven repo -->
         <!-- activate dependency with profile oracle 'mvn -Poracle install' instead -->
         <!-- <dependency> -->
@@ -80,34 +77,35 @@
         <!-- <version>12.1.0.1</version> -->
         <!-- <scope>provided</scope> -->
         <!-- </dependency> -->
-        <!-- used to colorize logging output on windows systems -->
-        <!--		<dependency>-->
-        <!--			<groupId>org.fusesource.jansi</groupId>-->
-        <!--			<artifactId>jansi</artifactId>-->
-        <!--			<version>1.17.1</version>-->
-        <!--			<scope>runtime</scope>-->
-        <!--		</dependency>-->
+
+        <!-- other dependencies -->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorLink</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
+            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
-            <artifactId>domibusConnectorDocumentation</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <groupId>org.vaadin.klaudeta</groupId>
+            <artifactId>grid-pagination</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>vaadin</artifactId>
+                    <groupId>com.vaadin</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorTestData</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -115,6 +113,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/domibusConnectorUILib/pom.xml
+++ b/domibusConnectorUILib/pom.xml
@@ -12,18 +12,20 @@
         <pmode.xsd.resources.path>src/main/resources/pmode/domibus_3_2_4</pmode.xsd.resources.path>
     </properties>
     <dependencies>
+        <!-- domibus modules and libs-->
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorControllerAPI</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>eu.domibus.connector</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>domibusConnectorPersistence</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
@@ -32,10 +34,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!-- other dependencies -->
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -67,7 +69,6 @@
                             <schemaIncludes>
                                 <include>domibus-pmode.xsd</include>
                             </schemaIncludes>
-                            <!--                            <generateDirectory>src/main/java</generateDirectory>-->
                             <strict>true</strict>
                             <extension>true</extension>
                             <args>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,25 @@
     <artifactId>domibusConnector</artifactId>
     <version>4.4.12-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <organization>
+        <name>eu-LISA</name>
+        <url>https://ecodex.eu</url>
+    </organization>
     <licenses>
         <license>
             <name>EUPL, version 1.2</name>
             <url>https://joinup.ec.europa.eu/collection/eupl/eupl-text-11-12</url>
         </license>
     </licenses>
+    <scm>
+        <url>https://github.com/eu-LISA/domibusConnector</url>
+        <connection>scm:git:git@github.com:eu-LISA/domibusConnector.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:eu-LISA/domibusConnector.git</developerConnection>
+    </scm>
+    <ciManagement>
+        <system>Github Actions</system>
+        <url>https://github.com/eu-LISA/domibusConnector/actions</url>
+    </ciManagement>
     <modules>
         <module>domibusConnectorEvidencesToolkit</module>
         <module>domibusConnectorSecurityToolkit</module>
@@ -31,163 +44,171 @@
         <module>domibusConnectorDistribution</module>
         <module>domibusConnectorDssToolkit</module>
     </modules>
-    <scm>
-        <developerConnection>scm:git:https://www.git.e-codex.eu/ecodex.git/domibusConnector</developerConnection>
-    </scm>
-    <ciManagement>
-        <system>Jenkins</system>
-        <url>https://secure.e-codex.eu/jenkins/view/domibusConnector/job/domibusWebConnector</url>
-    </ciManagement>
     <distributionManagement>
         <repository>
-            <id>${ecodex-releases-repo.id}</id>
-            <url>${ecodex-releases-repo.url}</url>
+            <id>central</id>
+            <name>e-CODEX Artifacts-releases</name>
+            <url>https://scm.ecodex.eu/artifactory/ecodex-releases</url>
         </repository>
         <snapshotRepository>
-            <id>${ecodex-snapshots-repo.id}</id>
-            <url>${ecodex-snapshots-repo.url}</url>
+            <id>snapshots</id>
+            <name>e-CODEX Artifacts-snapshots</name>
+            <url>https://scm.ecodex.eu/artifactory/ecodex-snapshots</url>
         </snapshotRepository>
         <site>
             <id>${project.artifactId}-site</id>
             <url>http://www.ecodex.eu/connector-site</url>
         </site>
     </distributionManagement>
-    <!-- Shared version number properties -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <name>libs-release</name>
+            <url>https://scm.ecodex.eu/artifactory/libs-release</url>
+        </repository>
+        <repository>
+            <snapshots/>
+            <id>snapshots</id>
+            <name>libs-snapshot</name>
+            <url>https://scm.ecodex.eu/artifactory/libs-snapshot</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>libs-release</name>
+            <url>https://scm.ecodex.eu/artifactory/libs-release</url>
+        </pluginRepository>
+        <pluginRepository>
+            <snapshots/>
+            <id>snapshots</id>
+            <name>libs-snapshot</name>
+            <url>https://scm.ecodex.eu/artifactory/libs-snapshot</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <!-- shared version number properties -->
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <tomcat.version>8.5.32</tomcat.version>
-        <javax.ws.rs>1.1.1</javax.ws.rs>
-        <org.codehaus.jackson>1.9.12</org.codehaus.jackson>
-        <maven.surefire.plugin.version>2.12.4</maven.surefire.plugin.version>
-        <com.sun.xml.bind.jaxb.version>2.3.0</com.sun.xml.bind.jaxb.version>
+        <!-- ecodex domibus libs-->
+        <eu.domibus.connector.plugin.version>4.4.0</eu.domibus.connector.plugin.version>
+        <eu.ecodex.utils.version>0.0.22-RELEASE</eu.ecodex.utils.version>
+        <!-- plugins -->
+        <com.github.ferstl.depgraph-maven-plugin.version>3.3.0</com.github.ferstl.depgraph-maven-plugin.version>
+        <eu.ecodex.spring-properties-reporting-plugin.version>0.9.2-RELEASE</eu.ecodex.spring-properties-reporting-plugin.version>
+        <maven.assembly-plugin.version>2.4</maven.assembly-plugin.version>
+        <maven.compiler-plugin.version>3.7.0</maven.compiler-plugin.version>
+        <maven.dependency-plugin.version>3.0.2</maven.dependency-plugin.version>
+        <maven.deploy-plugin.version>3.1.1</maven.deploy-plugin.version>
+        <maven.failsafe-plugin.version>3.0.0-M5</maven.failsafe-plugin.version>
+        <maven.jar-plugin.version>2.4</maven.jar-plugin.version>
+        <maven.javadoc-plugin.version>3.6.3</maven.javadoc-plugin.version>
+        <maven.resources-plugin.version>2.6</maven.resources-plugin.version>
+        <maven.source-plugin.version>2.2.1</maven.source-plugin.version>
+        <maven.surefire-plugin.version>3.0.0-M5</maven.surefire-plugin.version>
+        <maven.war-plugin.version>3.2.0</maven.war-plugin.version>
+        <org.codehaus.mojo.xml-maven-plugin>1.0.2</org.codehaus.mojo.xml-maven-plugin>
+        <org.jacoco.maven-plugin.version>0.7.9</org.jacoco.maven-plugin.version>
+        <!-- sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-        <jacoco.outputDir>${project.build.directory}/jacoco</jacoco.outputDir>
-        <jacoco.out.ut.file>jacoco-ut.exec</jacoco.out.ut.file>
-        <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
-        <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.reportPath>
-        <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
-        <!-- if a proxy is used during build or test configure this properties 
-			by overwriting them in your settings.xml file -->
-        <https.proxy.enabled>false</https.proxy.enabled>
-        <http.proxy.enabled>false</http.proxy.enabled>
-        <!-- keep this empty properties! -->
-        <https.proxy.host></https.proxy.host>
-        <http.proxy.host></http.proxy.host>
-        <http.proxy.port></http.proxy.port>
-        <https.proxy.port></https.proxy.port>
-        <releases-repo.url></releases-repo.url>
-        <snapshots-repo.url></snapshots-repo.url>
-        <https.proxy.port></https.proxy.port>
+        <!-- documentation -->
         <asciidoclet.version>1.5.6</asciidoclet.version>
         <asciidoctorj.version>2.5.2</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <asciidoctorj.diagram.version>2.2.1</asciidoctorj.diagram.version>
         <asciidoctorj.diagram.plantuml.version>1.2021.8</asciidoctorj.diagram.plantuml.version>
         <asciidoctorj.maven.plugin.version>2.2.1</asciidoctorj.maven.plugin.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <org.apache.cxf.version>3.4.10</org.apache.cxf.version>
         <!-- always update with cxf -->
-        <org.apache.santuario.xmlsec.version>2.2.4</org.apache.santuario.xmlsec.version>
         <com.fasterxml.woodstox.woodstox-core.version>6.4.0</com.fasterxml.woodstox.woodstox-core.version>
-        <spring.cloud.version>2.2.8.RELEASE</spring.cloud.version>
-        <spring.boot.version>2.5.15</spring.boot.version>
-        <eu.ecodex.utils.version>0.0.22-RELEASE</eu.ecodex.utils.version>
-        <org.junit.jupiter.version>5.9.1</org.junit.jupiter.version>
+        <org.apache.santuario.xmlsec.version>2.2.4</org.apache.santuario.xmlsec.version>
+        <!-- vaadin -->
         <vaadin.version>14.10.5</vaadin.version>
-        <!--        <spring-data-bom.version>2021.1.9</spring-data-bom.version>-->
-        <dss.tools.version>5.12.1</dss.tools.version>
-        <org.bouncycastl.version>1.70</org.bouncycastl.version>
-        <com.github.librepdf.openpdf.version>1.3.30</com.github.librepdf.openpdf.version>
-        <commons-cli.commons-cli.version>1.4</commons-cli.commons-cli.version>
-        <org.apache.log4j2.version>2.19.0</org.apache.log4j2.version>
-        <org.testcontainers.testcontainers.version>1.15.3</org.testcontainers.testcontainers.version>
-        <org.ow2.asm.asm.version>9.2</org.ow2.asm.asm.version>
-        <com.github.database-rider.rider-spring.version>1.10.1</com.github.database-rider.rider-spring.version>
-        <javax.xml.bind.jaxb-api.version>2.3.1</javax.xml.bind.jaxb-api.version>
+        <vaadin.grid-pagination.version>2.0.10</vaadin.grid-pagination.version>
+        <!-- soap web service -->
+        <com.sun.xml.bind.jaxb.version>2.3.0</com.sun.xml.bind.jaxb.version>
         <com.sun.xml.bind.jaxb-core.version>2.3.0</com.sun.xml.bind.jaxb-core.version>
         <com.sun.xml.bind.jaxb-impl.version>3.0.2</com.sun.xml.bind.jaxb-impl.version>
         <com.sun.xml.bind.jaxb-xjc.version>2.3.0</com.sun.xml.bind.jaxb-xjc.version>
-        <org.glassfish.jaxb.jaxb-runtime.version>2.3.8</org.glassfish.jaxb.jaxb-runtime.version>
-        <javax.xml.ws.jaxws-api.version>2.3.1</javax.xml.ws.jaxws-api.version>
         <jakarta.xml.soap.jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap.jakarta.xml.soap-api.version>
         <jakarta.jws.jakarta.jws-api.version>2.1.0</jakarta.jws.jakarta.jws-api.version>
-        <javax.jms.javax.jms-api.version>2.0.1</javax.jms.javax.jms-api.version>
-        <javax.validation.validation-api.version>2.0.1.Final</javax.validation.validation-api.version>
-        <javax.mail.mail.version>1.5.0-b01</javax.mail.mail.version>
+        <javax.xml.bind.jaxb-api.version>2.3.1</javax.xml.bind.jaxb-api.version>
+        <javax.xml.ws.jaxws-api.version>2.3.1</javax.xml.ws.jaxws-api.version>
+        <javax.ws.rs>1.1.1</javax.ws.rs>
+        <org.glassfish.jaxb.jaxb-runtime.version>2.3.8</org.glassfish.jaxb.jaxb-runtime.version>
+        <!-- database -->
+        <org.postgresql.postgresql.version>42.3.8</org.postgresql.postgresql.version>
+        <org.mariadb.jdbc.mariadb-java-client.version>3.0.9</org.mariadb.jdbc.mariadb-java-client.version>
+        <com.oracle.database.jdbc.ojdbc8.version>12.2.0.1</com.oracle.database.jdbc.ojdbc8.version>
+        <com.oracle.database.jdbc.ojdbc-bom.version>21.5.0.0</com.oracle.database.jdbc.ojdbc-bom.version>
+        <com.h2database.h2.version>2.0.206</com.h2database.h2.version>
+        <org.liquibase.liquibase-core.version>4.8.0</org.liquibase.liquibase-core.version>
+        <com.github.database-rider.rider-spring.version>1.10.1</com.github.database-rider.rider-spring.version>
+        <mysql.mysql-connector-java.version>8.0.32</mysql.mysql-connector-java.version>
+        <!-- other -->
+        <com.github.librepdf.openpdf.version>1.3.30</com.github.librepdf.openpdf.version>
+        <com.google.code.findbugs.jsr305.version>3.0.2</com.google.code.findbugs.jsr305.version>
+        <com.google.code.findbugs.annotations.version>3.0.1u2</com.google.code.findbugs.annotations.version>
+        <com.google.guava.version>30.1.1-jre</com.google.guava.version>
         <commons-lang.commons-lang.version>2.6</commons-lang.commons-lang.version>
         <commons-beanutils.commons-beanutils.version>1.9.4</commons-beanutils.commons-beanutils.version>
         <commons-collections.commons-collections.version>3.2.2</commons-collections.commons-collections.version>
         <commons-io.commons-io.version>2.5</commons-io.commons-io.version>
-        <xml-apis.xml-apis.version>1.4.1</xml-apis.xml-apis.version>
-        <com.google.code.findbugs.jsr305.version>3.0.2</com.google.code.findbugs.jsr305.version>
-        <com.google.code.findbugs.annotations.version>3.0.1u2</com.google.code.findbugs.annotations.version>
+        <commons-cli.commons-cli.version>1.4</commons-cli.commons-cli.version>
+        <dss.tools.version>5.12.1</dss.tools.version>
         <javax.annotation.javax.annotation-api>1.3.2</javax.annotation.javax.annotation-api>
+        <javax.jms.javax.jms-api.version>2.0.1</javax.jms.javax.jms-api.version>
+        <javax.mail.mail.version>1.5.0-b01</javax.mail.mail.version>
+        <javax.servlet-api>4.0.1</javax.servlet-api>
+        <javax.validation.validation-api.version>2.0.1.Final</javax.validation.validation-api.version>
         <org.apache.commons.commons-lang3.version>3.4</org.apache.commons.commons-lang3.version>
         <org.apache.commons.commons-compress.version>1.21</org.apache.commons.commons-compress.version>
+        <org.apache.log4j2.version>2.19.0</org.apache.log4j2.version>
         <org.apache.poi.poi.version>3.17</org.apache.poi.poi.version>
-        <org.xmlunit.xmlunit-matchers.version>2.5.1</org.xmlunit.xmlunit-matchers.version>
-        <org.xmlunit.xmlunit-core.version>2.5.1</org.xmlunit.xmlunit-core.version>
-        <org.dbunit.dbunit.version>2.7.3</org.dbunit.dbunit.version>
-        <com.google.guava.version>30.1.1-jre</com.google.guava.version>
-        <mysql.mysql-connector-java.version>8.0.32</mysql.mysql-connector-java.version>
-        <org.postgresql.postgresql.version>42.3.8</org.postgresql.postgresql.version>
-        <org.mariadb.jdbc.mariadb-java-client.version>3.0.9</org.mariadb.jdbc.mariadb-java-client.version>
-        <com.oracle.database.jdbc.ojdbc-bom.version>21.5.0.0</com.oracle.database.jdbc.ojdbc-bom.version>
-        <com.h2database.h2.version>2.0.206</com.h2database.h2.version>
-        <org.liquibase.liquibase-core.version>4.8.0</org.liquibase.liquibase-core.version>
         <org.apache.commons.commons-text.version>1.10.0</org.apache.commons.commons-text.version>
+        <org.codehaus.jackson>1.9.12</org.codehaus.jackson>
+        <org.bouncycastl.version>1.70</org.bouncycastl.version>
         <org.fusesource.jansi.jansi.version>2.4.0</org.fusesource.jansi.jansi.version>
+        <org.ow2.asm.asm.version>9.2</org.ow2.asm.asm.version>
+        <org.testcontainers.testcontainers.version>1.15.3</org.testcontainers.testcontainers.version>
+        <spring.cloud.version>2.2.8.RELEASE</spring.cloud.version>
+        <spring.boot.version>2.5.15</spring.boot.version>
+        <tomcat.version>8.5.32</tomcat.version>
+        <xml-apis.xml-apis.version>1.4.1</xml-apis.xml-apis.version>
+        <!-- testing -->
+        <assertj.version>3.19.0</assertj.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <jacoco.outputDir>${project.build.directory}/jacoco</jacoco.outputDir>
+        <jacoco.out.ut.file>jacoco-ut.exec</jacoco.out.ut.file>
+        <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
+        <junit.jupiter.api.version>5.7.1</junit.jupiter.api.version>
+        <junit.jupiter.engine.version>5.7.1</junit.jupiter.engine.version>
+        <org.dbunit.dbunit.version>2.7.3</org.dbunit.dbunit.version>
+        <org.junit.jupiter.version>5.9.1</org.junit.jupiter.version>
+        <org.xmlunit.xmlunit-core.version>2.5.1</org.xmlunit.xmlunit-core.version>
+        <org.xmlunit.xmlunit-matchers.version>2.5.1</org.xmlunit.xmlunit-matchers.version>
+        <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
+        <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.reportPath>
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!--            <dependency>-->
-            <!--                <groupId>org.springframework.data</groupId>-->
-            <!--                <artifactId>spring-data-bom</artifactId>-->
-            <!--                <version>${spring-data-bom.version}</version>-->
-            <!--                <type>pom</type>-->
-            <!--                <scope>import</scope>-->
-            <!--            </dependency>-->
+            <!-- domibus modules and libs-->
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>eu.domibus.connector.plugin</groupId>
+                <artifactId>domibus-connector-plugin-distribution</artifactId>
+                <version>${eu.domibus.connector.plugin.version}</version>
+                <type>zip</type>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <version>${vaadin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-spring-boot-starter</artifactId>
-                <version>${vaadin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-bom</artifactId>
-                <version>${org.apache.cxf.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>eu.ecodex.utils</groupId>
-                <artifactId>ecodex-dependencies</artifactId>
-                <version>${eu.ecodex.utils.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.fusesource.jansi</groupId>
-                <artifactId>jansi</artifactId>
-                <version>${org.fusesource.jansi.jansi.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>eu.ecodex.utils</groupId>
                 <artifactId>logging-tester</artifactId>
@@ -198,11 +219,45 @@
                 <artifactId>spring-property-configuration-manager</artifactId>
                 <version>${eu.ecodex.utils.version}</version>
             </dependency>
+            <!-- spring dependencies -->
             <dependency>
-                <groupId>com.github.librepdf</groupId>
-                <artifactId>openpdf</artifactId>
-                <version>${com.github.librepdf.openpdf.version}</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter</artifactId>
+                <version>${spring.boot.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>spring-boot-starter-logging</artifactId>
+                        <groupId>org.springframework.boot</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <groupId>org.junit.vintage</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${spring.boot.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>junit</artifactId>
+                        <groupId>junit</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <groupId>org.junit.vintage</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- dss dependencies -->
             <dependency>
                 <groupId>eu.europa.ec.joinup.sd-dss</groupId>
                 <artifactId>dss-document</artifactId>
@@ -264,6 +319,25 @@
                 <artifactId>dss-token</artifactId>
                 <version>${dss.tools.version}</version>
             </dependency>
+            <!-- vaadin dependencies -->
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-bom</artifactId>
+                <version>${vaadin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.vaadin.klaudeta</groupId>
+                <artifactId>grid-pagination</artifactId>
+                <version>${vaadin.grid-pagination.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-spring-boot-starter</artifactId>
+                <version>${vaadin.version}</version>
+            </dependency>
+            <!-- bouncy castle dependencies -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
@@ -320,276 +394,7 @@
                 <artifactId>jakarta.jws-api</artifactId>
                 <version>${jakarta.jws.jakarta.jws-api.version}</version>
             </dependency>
-            <dependency>
-                <groupId>commons-cli</groupId>
-                <artifactId>commons-cli</artifactId>
-                <version>${commons-cli.commons-cli.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers</artifactId>
-                <version>${org.testcontainers.testcontainers.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>visible-assertions</artifactId>
-                        <groupId>org.rnorth.visible-assertions</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jna</artifactId>
-                        <groupId>net.java.dev.jna</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${org.testcontainers.testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter</artifactId>
-                <version>${spring.boot.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>spring-boot-starter-logging</artifactId>
-                        <groupId>org.springframework.boot</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>junit-vintage-engine</artifactId>
-                        <groupId>org.junit.vintage</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${spring.boot.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>junit</artifactId>
-                        <groupId>junit</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>junit-vintage-engine</artifactId>
-                        <groupId>org.junit.vintage</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${org.ow2.asm.asm.version}</version>
-            </dependency>
-            <!-- Apache CXF dependencies -->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-core</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-frontend-jaxws</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-features</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-features-logging</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-ws-addr</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-ws</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-transports-jms</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-transports-http</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-bindings-soap</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-ws-security</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <!--            <dependency>-->
-            <!--                <groupId>org.apache.cxf</groupId>-->
-            <!--                <artifactId>cxf-rt-ws-policy</artifactId>-->
-            <!--                <version>${org.apache.cxf.version}</version>-->
-            <!--            </dependency>-->
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-spring-boot-starter-jaxws</artifactId>
-                <version>${org.apache.cxf.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>logback-core</artifactId>
-                        <groupId>ch.qos.logback</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>logback-classic</artifactId>
-                        <groupId>ch.qos.logback</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.santuario</groupId>
-                <artifactId>xmlsec</artifactId>
-                <version>${org.apache.santuario.xmlsec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.woodstox</groupId>
-                <artifactId>woodstox-core</artifactId>
-                <version>${com.fasterxml.woodstox.woodstox-core.version}</version>
-            </dependency>
-            <!-- exclude xmlsec -->
-            <dependency>
-                <groupId>org.opensaml</groupId>
-                <artifactId>opensaml-security-api</artifactId>
-                <version>(3.3.1,)</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>xmlsec</artifactId>
-                        <groupId>org.apache.santuario</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>javax.jms</groupId>
-                <artifactId>javax.jms-api</artifactId>
-                <version>${javax.jms.javax.jms-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${javax.validation.validation-api.version}</version>
-            </dependency>
-            <!-- Other dependencies -->
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.commons-lang.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils.commons-beanutils.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.commons-collections.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <version>${javax.ws.rs}</version>
-            </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>${xml-apis.xml-apis.version}</version>
-            </dependency>
-            <!-- findbugs -->
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${com.google.code.findbugs.jsr305.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${com.google.code.findbugs.annotations.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${javax.annotation.javax.annotation-api}</version>
-            </dependency>
-            <!-- commons lang -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${org.apache.commons.commons-lang3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>${org.apache.commons.commons-compress.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>${org.apache.commons.commons-text.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.poi</groupId>
-                <artifactId>poi</artifactId>
-                <version>${org.apache.poi.poi.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-collections4</artifactId>
-                        <groupId>org.apache.commons</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${com.google.guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
-                <version>${javax.mail.mail.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-matchers</artifactId>
-                <version>${org.xmlunit.xmlunit-matchers.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-core</artifactId>
-                <version>${org.xmlunit.xmlunit-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.dbunit</groupId>
-                <artifactId>dbunit</artifactId>
-                <version>${org.dbunit.dbunit.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>junit</artifactId>
-                        <groupId>junit</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
+            <!-- database -->
             <dependency>
                 <groupId>com.github.database-rider</groupId>
                 <artifactId>rider-spring</artifactId>
@@ -630,6 +435,12 @@
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc8</artifactId>
+                <version>${com.oracle.database.jdbc.ojdbc8.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc-bom</artifactId>
                 <version>${com.oracle.database.jdbc.ojdbc-bom.version}</version>
                 <type>pom</type>
@@ -646,129 +457,301 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- findbugs -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${com.google.code.findbugs.jsr305.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${com.google.code.findbugs.annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${javax.annotation.javax.annotation-api}</version>
+            </dependency>
+            <!-- commons lang -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${org.apache.commons.commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${org.apache.commons.commons-compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${org.apache.commons.commons-text.version}</version>
+            </dependency>
+            <!-- other dependencies -->
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>${commons-cli.commons-cli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${org.testcontainers.testcontainers.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>visible-assertions</artifactId>
+                        <groupId>org.rnorth.visible-assertions</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jna</artifactId>
+                        <groupId>net.java.dev.jna</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${org.testcontainers.testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${org.ow2.asm.asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.santuario</groupId>
+                <artifactId>xmlsec</artifactId>
+                <version>${org.apache.santuario.xmlsec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${com.fasterxml.woodstox.woodstox-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-security-api</artifactId>
+                <version>(3.3.1,)</version>
+                <!-- exclude xmlsec -->
+                <exclusions>
+                    <exclusion>
+                        <artifactId>xmlsec</artifactId>
+                        <groupId>org.apache.santuario</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>javax.jms</groupId>
+                <artifactId>javax.jms-api</artifactId>
+                <version>${javax.jms.javax.jms-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation.validation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.commons-lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons-beanutils.commons-beanutils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>jsr311-api</artifactId>
+                <version>${javax.ws.rs}</version>
+            </dependency>
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>${xml-apis.xml-apis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax.servlet-api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-bom</artifactId>
+                <version>${org.apache.cxf.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-spring-boot-starter-jaxws</artifactId>
+                <version>${org.apache.cxf.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>logback-core</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>logback-classic</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-frontend-jaxws</artifactId>
+                <version>${org.apache.cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>eu.ecodex.utils</groupId>
+                <artifactId>ecodex-dependencies</artifactId>
+                <version>${eu.ecodex.utils.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>${org.fusesource.jansi.jansi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.librepdf</groupId>
+                <artifactId>openpdf</artifactId>
+                <version>${com.github.librepdf.openpdf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi</artifactId>
+                <version>${org.apache.poi.poi.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-collections4</artifactId>
+                        <groupId>org.apache.commons</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${com.google.guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>mail</artifactId>
+                <version>${javax.mail.mail.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-matchers</artifactId>
+                <version>${org.xmlunit.xmlunit-matchers.version}</version>
+            </dependency>
+            <!-- tests -->
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.jupiter.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.jupiter.engine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dbunit</groupId>
+                <artifactId>dbunit</artifactId>
+                <version>${org.dbunit.dbunit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>junit</artifactId>
+                        <groupId>junit</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-core</artifactId>
+                <version>${org.xmlunit.xmlunit-core.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>fabric8-maven-plugin</artifactId>
-                    <version>4.4.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.14.1</version>
-                    <configuration>
-                        <allowMinorUpdates>false</allowMinorUpdates>
-                        <excludeProperties>com.oracle.database.jdbc.ojdbc-bom.version</excludeProperties>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>eu.ecodex.connector.utils.property-reporting</groupId>
-                    <artifactId>spring-properties-reporting-plugin</artifactId>
-                    <version>0.9.2-RELEASE</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.github.ferstl</groupId>
-                    <artifactId>depgraph-maven-plugin</artifactId>
-                    <version>3.3.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-maven-plugin</artifactId>
-                    <version>${vaadin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.0</version>
-                    <configuration>
-                        <allowMajorUpdates>false</allowMajorUpdates>
-                        <allowMinorUpdates>false</allowMinorUpdates>
-                        <allowIncrementalUpdates>true</allowIncrementalUpdates>
-                        <ignoredVersions>.*-M.*,.*-alpha.*,.*-RC.*</ignoredVersions>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.9</version>
-                </plugin>
+                <!-- maven -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.9.1</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                        <encoding>UTF-8</encoding>
-                        <meminitial>1024m</meminitial>
-                        <maxmem>2024m</maxmem>
+                        <skip>true</skip>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven.javadoc-plugin.version}</version>
                     <configuration>
-                        <failOnMissingWebXml>false</failOnMissingWebXml>
-                        <attachClasses>true</attachClasses>
+                        <!-- fix error javax.interceptor.InterceptorBinding not found -->
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>javax.interceptor</groupId>
+                                <artifactId>javax.interceptor-api</artifactId>
+                                <version>1.2.2</version>
+                            </additionalDependency>
+                        </additionalDependencies>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven.deploy-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven.failsafe-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>${org.junit.jupiter.version}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
-                        <nonFilteredFileExtensions>
-                            <nonFilteredFileExtension>jks</nonFilteredFileExtension>
-                        </nonFilteredFileExtensions>
-                        <encoding>UTF-8</encoding>
+                        <argLine>-Djunit.jupiter.extensions.autodetection.enabled=true</argLine>
+                        <forkCount>1</forkCount>
+                        <reuseForks>false</reuseForks>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>${maven.surefire-plugin.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.junit.jupiter</groupId>
@@ -785,25 +768,73 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.0.0-M5</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.junit.jupiter</groupId>
-                            <artifactId>junit-jupiter-engine</artifactId>
-                            <version>${org.junit.jupiter.version}</version>
-                        </dependency>
-                    </dependencies>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven.resources-plugin.version}</version>
                     <configuration>
-                        <argLine>-Djunit.jupiter.extensions.autodetection.enabled=true</argLine>
-                        <forkCount>1</forkCount>
-                        <reuseForks>false</reuseForks>
+                        <nonFilteredFileExtensions>
+                            <nonFilteredFileExtension>jks</nonFilteredFileExtension>
+                        </nonFilteredFileExtensions>
+                        <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.jvnet.jaxb2.maven2</groupId>
-                    <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.15.1</version>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler-plugin.version}</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <encoding>UTF-8</encoding>
+                        <meminitial>1024m</meminitial>
+                        <maxmem>2024m</maxmem>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven.war-plugin.version}</version>
+                    <configuration>
+                        <failOnMissingWebXml>false</failOnMissingWebXml>
+                        <attachClasses>true</attachClasses>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven.jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven.source-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven.assembly-plugin.version}</version>
+                </plugin>
+                <!-- codehaus -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>xml-maven-plugin</artifactId>
+                    <version>${org.codehaus.mojo.xml-maven-plugin}</version>
+                </plugin>
+                <!-- ecodex -->
+                <plugin>
+                    <groupId>eu.ecodex.connector.utils.property-reporting</groupId>
+                    <artifactId>spring-properties-reporting-plugin</artifactId>
+                    <version>${eu.ecodex.spring-properties-reporting-plugin.version}</version>
+                </plugin>
+                <!-- other -->
+                <plugin>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-maven-plugin</artifactId>
+                    <version>${vaadin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.cxf</groupId>
@@ -811,91 +842,39 @@
                     <version>${org.apache.cxf.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.jvnet.jaxb2.maven2</groupId>
+                    <artifactId>maven-jaxb2-plugin</artifactId>
+                    <version>0.15.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring.boot.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <groupId>com.github.ferstl</groupId>
+                    <artifactId>depgraph-maven-plugin</artifactId>
+                    <version>${com.github.ferstl.depgraph-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
-                    <configuration>
-                        <!-- fix error javax.interceptor.InterceptorBinding not found -->
-                        <additionalDependencies>
-                            <additionalDependency>
-                                <groupId>javax.interceptor</groupId>
-                                <artifactId>javax.interceptor-api</artifactId>
-                                <version>1.2.2</version>
-                            </additionalDependency>
-                        </additionalDependencies>
-                        <!-- <doclet>org.asciidoctor.Asciidoclet</doclet> <docletArtifact> 
-							<groupId>org.asciidoctor</groupId> <artifactId>asciidoclet</artifactId> <version>${asciidoclet.version}</version> 
-							</docletArtifact> <overview>src/main/java/overview.adoc</overview> <additionalparam> 
-							- -base-dir ${project.basedir} - -attribute "name=${project.name}" - -attribute 
-							"version=${project.version}" - -attribute "title-link=https://example.com[${project.name} 
-							${project.version}]" </additionalparam> -->
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.27.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.9.1</version>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${org.jacoco.maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- maven plugins -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>2.12.0</version>
-                <configuration>
-                    <allowMajorUpdates>false</allowMajorUpdates>
-                    <allowMinorUpdates>false</allowMinorUpdates>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.atlassian.maven.plugins</groupId>
-                <artifactId>maven-jgitflow-plugin</artifactId>
-                <version>1.0-alpha21.1</version>
-                <configuration>
-                    <allowSnapshots>false</allowSnapshots>
-                    <allowUntracked>false</allowUntracked>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <flowInitContext>
-                        <masterBranchName>master</masterBranchName>
-                        <developBranchName>development</developBranchName>
-                        <featureBranchPrefix>feature/</featureBranchPrefix>
-                        <releaseBranchPrefix>release/</releaseBranchPrefix>
-                        <hotfixBranchPrefix>hotfix/</hotfixBranchPrefix>
-                        <versionTagPrefix></versionTagPrefix>
-                    </flowInitContext>
-                    <pushFeatures>false</pushFeatures>
-                    <pushHotfixes>false</pushHotfixes>
-                    <pushReleases>false</pushReleases>
-                    <updateDependencies>true</updateDependencies>
-                    <keepBranch>true</keepBranch>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.eclipse.jkube</groupId>
-                <artifactId>openshift-maven-plugin</artifactId>
-                <version>1.7.0</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -917,62 +896,73 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <!-- deactivate unit testing with surefire -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <!-- Prepares a variable, jacoco.agent.ut.arg, that contains the info 
-						to be passed to the JVM hosting the code being tested. -->
-                    <execution>
-                        <id>prepare-ut-agent</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                        <configuration>
-                            <destFile>${sonar.jacoco.reportPath}</destFile>
-                            <propertyName>jacoco.agent.ut.arg</propertyName>
-                            <append>true</append>
-                        </configuration>
-                    </execution>
-                    <!--<!– Prepares a variable, jacoco.agent.it.arg, that contains the 
-						info to be passed to the JVM hosting the code being tested. –> -->
-                    <execution>
-                        <id>prepare-it-agent</id>
-                        <!--<!– moved to package phase to be sure all pre-integration test 
-							have it already set to bring up environments with jacoco agent as JVM params 
-							–> -->
-                        <phase>package</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <destFile>${sonar.jacoco.itReportPath}</destFile>
-                            <propertyName>jacoco.agent.it.arg</propertyName>
-                            <append>true</append>
-                        </configuration>
-                    </execution>
-                </executions>
                 <configuration>
-                    <excludes>
-                        <exclude>**/*.docx</exclude>
-                        <exclude>**/*.pdf</exclude>
-                        <exclude>**/*.zip</exclude>
-                    </excludes>
+                    <skip>true</skip>
+                    <skipTests>true</skipTests>
                 </configuration>
             </plugin>
+            <!-- activate unit testing with failsafe -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>execute-unit-tests</id>
+                        <phase>test</phase>
                         <goals>
-                            <goal>test-jar</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <!-- to be deleted and replaced by CI jacoco config -->
+                            <argLine>@{jacoco.agent.ut.arg}</argLine>
+                            <includes>
+                                <include>**/*Test.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/IT*.java</exclude>
+                                <exclude>**/*IT.java</exclude>
+                                <exclude>**/*ITCase.java</exclude>
+                            </excludes>
+                            <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>executeITCases</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- to be deleted and replaced by CI jacoco config -->
+                            <argLine>@{jacoco.agent.it.arg}</argLine>
+                            <reportsDirectory>${project.build.directory}/ittest-reports</reportsDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>executeDBUnitCases</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- to be deleted and replaced by CI jacoco config -->
+                            <argLine>@{jacoco.agent.it.arg}</argLine>
+                            <includes>
+                                <include>**/*DBUnit.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/IT*.java</exclude>
+                                <exclude>**/*IT.java</exclude>
+                                <exclude>**/*ITCase.java</exclude>
+                            </excludes>
+                            <reportsDirectory>${project.build.directory}/dbunit-reports</reportsDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -990,7 +980,6 @@
                 </executions>
                 <configuration>
                     <rules>
-                        <dependencyConvergence></dependencyConvergence>
                         <bannedDependencies>
                             <searchTransitive>true</searchTransitive>
                             <excludes>
@@ -1015,6 +1004,89 @@
                             <version>11</version>
                         </requireJavaVersion>
                     </rules>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>deploy-ecodex</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- other plugins -->
+            <plugin>
+                <groupId>org.eclipse.jkube</groupId>
+                <artifactId>openshift-maven-plugin</artifactId>
+                <version>1.7.0</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                    Prepares a variable, jacoco.agent.ut.arg, that contains the info
+                    to be passed to the JVM hosting the code being tested.
+                    -->
+                    <execution>
+                        <id>prepare-ut-agent</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${sonar.jacoco.reportPath}</destFile>
+                            <propertyName>jacoco.agent.ut.arg</propertyName>
+                            <append>true</append>
+                        </configuration>
+                    </execution>
+                    <!--
+                    Prepares a variable, jacoco.agent.it.arg, that contains the
+                    info to be passed to the JVM hosting the code being tested.
+                    -->
+                    <execution>
+                        <id>prepare-it-agent</id>
+                        <!--
+                        moved to package phase to be sure all pre-integration test
+                        have it already set to bring up environments with jacoco agent as JVM params
+                        -->
+                        <phase>package</phase>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${sonar.jacoco.itReportPath}</destFile>
+                            <propertyName>jacoco.agent.it.arg</propertyName>
+                            <append>true</append>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.docx</exclude>
+                        <exclude>**/*.pdf</exclude>
+                        <exclude>**/*.zip</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -1046,187 +1118,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>javadoc</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>buildserver</id>
-            <activation>
-                <property>
-                    <name>env.BUILD_NUMBER</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <!--                    <plugin>-->
-                    <!--                        <groupId>com.buschmais.jqassistant</groupId>-->
-                    <!--                        <artifactId>jqassistant-maven-plugin</artifactId>-->
-                    <!--                        <executions>-->
-                    <!--                            <execution>-->
-                    <!--                                <goals>-->
-                    <!--                                    <goal>scan</goal>-->
-                    <!--                                    <goal>analyze</goal>-->
-                    <!--                                </goals>-->
-                    <!--                                <configuration>-->
-                    <!--                                    <warnOnSeverity>MINOR</warnOnSeverity>-->
-                    <!--                                    <failOnSeverity>MAJOR</failOnSeverity>-->
-                    <!--                                </configuration>-->
-                    <!--                            </execution>-->
-                    <!--                        </executions>-->
-                    <!--                    </plugin>-->
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deploy-ecodex</id>
-            <distributionManagement>
-                <repository>
-                    <id>nexus-releases</id>
-                    <url>https://secure.e-codex.eu/nexus/content/repositories/releases/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>nexus-snapshots</id>
-                    <url>https://secure.e-codex.eu/nexus/content/repositories/snapshots/</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-        <profile>
-            <!-- activates long running integration tests -->
-            <id>unit-testing-with-failsafe</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                            <skipTests>true</skipTests>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>executeUnitTests</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <argLine>${jacoco.agent.ut.arg}</argLine>
-                            <includes>
-                                <include>**/*Test.java</include>
-                            </includes>
-                            <excludes>
-                                <exclude>**/IT*.java</exclude>
-                                <exclude>**/*IT.java</exclude>
-                                <exclude>**/*ITCase.java</exclude>
-                            </excludes>
-                            <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <!-- activates long running integration tests -->
-            <id>integration-testing</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                            <skipTests>true</skipTests>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>executeITCases</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <reportsDirectory>${project.build.directory}/ittest-reports</reportsDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <argLine>${jacoco.agent.it.arg}</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <!-- starts during integration-test phase long running database tests -->
-            <id>dbunit-testing</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                            <skipTests>true</skipTests>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>executeDBUnitCases</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <argLine>${jacoco.agent.it.arg}</argLine>
-                                    <includes>
-                                        <include>**/*DBUnit.java</include>
-                                    </includes>
-                                    <excludes>
-                                        <exclude>**/IT*.java</exclude>
-                                        <exclude>**/*IT.java</exclude>
-                                        <exclude>**/*ITCase.java</exclude>
-                                    </excludes>
-                                    <reportsDirectory>${project.build.directory}/dbunit-reports</reportsDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
- reorder properties
- reorder dependencies
- reorder plugins
- set Jfrog artifactory URL
- set by default release and snapshot distribution management URLs
- generate Javadoc by default
- change the version of the Javadoc plugin from 3.0.1 to 3.6.3
- make modules pom files dependencies and plugins depend on those configured in the main POM file