### PR TITLE
fix(pom): replace artemis jms with jakarta

### DIFF
--- a/domibusConnectorController/pom.xml
+++ b/domibusConnectorController/pom.xml
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-jms-server</artifactId>
+            <artifactId>artemis-jakarta-server</artifactId>
             <exclusions>
                 <exclusion>
                     <artifactId>jboss-logmanager</artifactId>


### PR DESCRIPTION
artemis version 3 has different artifacts for the two different namespaces, during the migration to jakarta this was not noticed